### PR TITLE
Migrate to QGIS 4.0 (Qt6) with dual Qt5+Qt6 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+
+jobs:
+    bandit:
+        name: Bandit security scan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+            - name: Install Bandit
+              run: pip install bandit
+            - name: Run Bandit (matches plugins.qgis.org security scan)
+              run: bandit -r terrascope
+
+    pyqt6-smoke:
+        name: PyQt6 import smoke (Python ${{ matrix.python-version }})
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.11", "3.12", "3.13"]
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install Qt6 runtime libs
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+            - name: Install PyQt6 and pytest
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install PyQt6 pytest
+            - name: Run import smoke tests
+              run: pytest tests -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,10 @@ repos:
       rev: 0.9.1
       hooks:
           - id: nbstripout
+
+    - repo: https://github.com/PyCQA/bandit
+      rev: 1.9.4
+      hooks:
+          - id: bandit
+            args: ["-r", "terrascope"]
+            pass_filenames: false

--- a/terrascope/auth.py
+++ b/terrascope/auth.py
@@ -17,7 +17,7 @@ _logger = logging.getLogger(__name__)
 
 # Environment variable names
 ENV_USERNAME = "TERRASCOPE_USERNAME"
-ENV_PASSWORD = "TERRASCOPE_PASSWORD"
+ENV_PASSWORD = "TERRASCOPE_PASSWORD"  # nosec B105 - env var name, not a credential
 
 
 class TerrascopeAuth:

--- a/terrascope/dialogs/dependency_dialog.py
+++ b/terrascope/dialogs/dependency_dialog.py
@@ -142,7 +142,7 @@ class DependencyDialog(QDialog):
         header_font.setPointSize(13)
         header_font.setBold(True)
         header.setFont(header_font)
-        header.setAlignment(Qt.AlignCenter)
+        header.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header)
 
         # Required packages group
@@ -178,7 +178,7 @@ class DependencyDialog(QDialog):
         # Status label
         self.status_label = QLabel("")
         self.status_label.setWordWrap(True)
-        self.status_label.setAlignment(Qt.AlignCenter)
+        self.status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.status_label.setVisible(False)
         layout.addWidget(self.status_label)
 
@@ -208,7 +208,7 @@ class DependencyDialog(QDialog):
         info_label = QLabel(
             f"<small>Packages are installed in {escape(VENV_DIR)}</small>"
         )
-        info_label.setAlignment(Qt.AlignCenter)
+        info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         info_label.setStyleSheet("color: gray;")
         layout.addWidget(info_label)
 
@@ -301,10 +301,10 @@ class DependencyDialog(QDialog):
                 self,
                 "Installation in Progress",
                 "An installation is in progress. Are you sure you want to cancel?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
-            if reply != QMessageBox.Yes:
+            if reply != QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
             self._worker.cancel()

--- a/terrascope/dialogs/search_dock.py
+++ b/terrascope/dialogs/search_dock.py
@@ -229,7 +229,9 @@ class SearchDockWidget(QDockWidget):
         self._footprint_layer = None
         self._updating_selection = False
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         self._setup_ui()
 
@@ -273,7 +275,7 @@ class SearchDockWidget(QDockWidget):
                 self._on_layer_will_be_removed
             )
         except Exception:
-            pass
+            pass  # nosec B110 - signal may already be disconnected on close
         super().closeEvent(event)
 
     def _setup_ui(self):
@@ -288,7 +290,9 @@ class SearchDockWidget(QDockWidget):
         coll_row = QHBoxLayout()
         self.collection_combo = QComboBox()
         self.collection_combo.setEditable(True)
-        self.collection_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.collection_combo.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
         self.collection_combo.currentTextChanged.connect(self._on_collection_changed)
         coll_row.addWidget(self.collection_combo, 1)
 
@@ -466,7 +470,7 @@ class SearchDockWidget(QDockWidget):
         layout.addWidget(self.progress_bar)
 
         self.status_label = QLabel("")
-        self.status_label.setAlignment(Qt.AlignCenter)
+        self.status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.status_label.setVisible(False)
         layout.addWidget(self.status_label)
 
@@ -475,11 +479,13 @@ class SearchDockWidget(QDockWidget):
         self.results_table.setColumnCount(4)
         self.results_table.setHorizontalHeaderLabels(["Date", "ID", "Cloud %", ""])
         header = self.results_table.horizontalHeader()
-        header.setSectionResizeMode(QHeaderView.Interactive)
-        header.setSectionResizeMode(1, QHeaderView.Stretch)
-        header.setSectionResizeMode(3, QHeaderView.ResizeToContents)
-        self.results_table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.results_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        self.results_table.setSelectionBehavior(
+            QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.results_table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.results_table.setSortingEnabled(True)
         self.results_table.horizontalHeader().setSectionsClickable(True)
         self.results_table.itemSelectionChanged.connect(
@@ -838,9 +844,9 @@ class SearchDockWidget(QDockWidget):
                 self,
                 "Terrascope",
                 "Bounding box is all zeros. Search without spatial filter?",
-                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             )
-            if reply == QMessageBox.No:
+            if reply == QMessageBox.StandardButton.No:
                 return
             bbox = None
 
@@ -904,12 +910,14 @@ class SearchDockWidget(QDockWidget):
 
         for row, item in enumerate(items):
             date_item = QTableWidgetItem(item["date_str"])
-            date_item.setData(Qt.UserRole, row)
+            date_item.setData(Qt.ItemDataRole.UserRole, row)
             self.results_table.setItem(row, 0, date_item)
             self.results_table.setItem(row, 1, QTableWidgetItem(item["id"]))
             cloud = item.get("cloud_cover")
             cloud_item = QTableWidgetItem()
-            cloud_item.setData(Qt.DisplayRole, cloud if cloud is not None else "N/A")
+            cloud_item.setData(
+                Qt.ItemDataRole.DisplayRole, cloud if cloud is not None else "N/A"
+            )
             self.results_table.setItem(row, 2, cloud_item)
 
             # Link button
@@ -979,7 +987,7 @@ class SearchDockWidget(QDockWidget):
                 "Terrascope",
                 "You are not logged in. COG layers require authentication.\n\n"
                 "Please login via the Settings panel first.",
-                QMessageBox.Ok,
+                QMessageBox.StandardButton.Ok,
             )
             return False
         return True
@@ -1002,7 +1010,7 @@ class SearchDockWidget(QDockWidget):
         for visual_row in sorted(selected_visual_rows):
             date_item = self.results_table.item(visual_row, 0)
             if date_item is not None:
-                data_indices.append(date_item.data(Qt.UserRole))
+                data_indices.append(date_item.data(Qt.ItemDataRole.UserRole))
 
         if not data_indices:
             return
@@ -1143,7 +1151,7 @@ class SearchDockWidget(QDockWidget):
         for visual_row in sorted(selected_visual_rows):
             date_item = self.results_table.item(visual_row, 0)
             if date_item is not None:
-                data_indices.append(date_item.data(Qt.UserRole))
+                data_indices.append(date_item.data(Qt.ItemDataRole.UserRole))
 
         if not data_indices:
             return
@@ -1273,13 +1281,13 @@ class SearchDockWidget(QDockWidget):
                         self._on_footprint_selection_changed
                     )
                 except Exception:
-                    pass
+                    pass  # nosec B110 - signal may already be disconnected
                 try:
                     QgsProject.instance().layerWillBeRemoved.disconnect(
                         self._on_layer_will_be_removed
                     )
                 except Exception:
-                    pass
+                    pass  # nosec B110 - signal may already be disconnected
                 QgsProject.instance().removeMapLayer(self._footprint_layer.id())
             self._footprint_layer = None
 
@@ -1310,13 +1318,13 @@ class SearchDockWidget(QDockWidget):
                     self._on_footprint_selection_changed
                 )
             except Exception:
-                pass
+                pass  # nosec B110 - signal may already be disconnected
             try:
                 QgsProject.instance().layerWillBeRemoved.disconnect(
                     self._on_layer_will_be_removed
                 )
             except Exception:
-                pass
+                pass  # nosec B110 - signal may already be disconnected
             self._footprint_layer = None
 
     def _on_table_selection_changed(self):
@@ -1331,7 +1339,7 @@ class SearchDockWidget(QDockWidget):
             for item in self.results_table.selectedItems():
                 date_item = self.results_table.item(item.row(), 0)
                 if date_item is not None:
-                    idx = date_item.data(Qt.UserRole)
+                    idx = date_item.data(Qt.ItemDataRole.UserRole)
                     if idx is not None:
                         selected_data_indices.add(idx)
 
@@ -1386,7 +1394,7 @@ class SearchDockWidget(QDockWidget):
             for row in range(self.results_table.rowCount()):
                 date_item = self.results_table.item(row, 0)
                 if date_item is not None:
-                    idx = date_item.data(Qt.UserRole)
+                    idx = date_item.data(Qt.ItemDataRole.UserRole)
                     if idx in selected_data_indices:
                         self.results_table.selectRow(row)
         finally:

--- a/terrascope/dialogs/settings_dock.py
+++ b/terrascope/dialogs/settings_dock.py
@@ -68,7 +68,9 @@ class SettingsDockWidget(QDockWidget):
         self._get_auth = get_auth
         self._workers = []
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         self._settings = QSettings()
         self._setup_ui()
@@ -124,7 +126,7 @@ class SettingsDockWidget(QDockWidget):
         auth_form.addRow("Username:", self.username_edit)
 
         self.password_edit = QLineEdit()
-        self.password_edit.setEchoMode(QLineEdit.Password)
+        self.password_edit.setEchoMode(QLineEdit.EchoMode.Password)
         self.password_edit.setPlaceholderText("Terrascope password")
         auth_form.addRow("Password:", self.password_edit)
 
@@ -151,7 +153,7 @@ class SettingsDockWidget(QDockWidget):
         # Status
         self.auth_status_label = QLabel("Not authenticated")
         self.auth_status_label.setStyleSheet("color: gray; font-weight: bold;")
-        self.auth_status_label.setAlignment(Qt.AlignCenter)
+        self.auth_status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         auth_layout.addWidget(self.auth_status_label)
 
         auth_layout.addStretch()
@@ -423,7 +425,7 @@ class SettingsDockWidget(QDockWidget):
         from .dependency_dialog import DependencyDialog
 
         dialog = DependencyDialog(self)
-        dialog.exec_()
+        dialog.exec()
         self._update_dep_status()
 
     def _update_dep_status(self):

--- a/terrascope/dialogs/time_series_dock.py
+++ b/terrascope/dialogs/time_series_dock.py
@@ -61,7 +61,9 @@ class TimeSeriesDockWidget(QDockWidget):
         self._last_data = None
         self._last_point = None
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         self._setup_ui()
 
@@ -113,7 +115,7 @@ class TimeSeriesDockWidget(QDockWidget):
                 "matplotlib is required for plotting.\n"
                 "Install with: pip install matplotlib"
             )
-            no_mpl_label.setAlignment(Qt.AlignCenter)
+            no_mpl_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             no_mpl_label.setStyleSheet("color: red;")
             layout.addWidget(no_mpl_label)
 
@@ -195,7 +197,7 @@ class TimeSeriesDockWidget(QDockWidget):
         self.lon_label.setText(f"{display_point.x():.4f}")
 
         # Show wait cursor while extracting pixel values
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
         try:
             self._extract_and_plot(point, display_point, canvas_crs, time_steps)
         finally:

--- a/terrascope/dialogs/time_slider_dock.py
+++ b/terrascope/dialogs/time_slider_dock.py
@@ -89,7 +89,9 @@ class TimeSliderDockWidget(QDockWidget):
         self._auto_play_timer = QTimer(self)
         self._auto_play_timer.timeout.connect(self._auto_play_step)
 
-        self.setAllowedAreas(Qt.TopDockWidgetArea | Qt.BottomDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.TopDockWidgetArea | Qt.DockWidgetArea.BottomDockWidgetArea
+        )
 
         self._setup_ui()
 
@@ -134,16 +136,16 @@ class TimeSliderDockWidget(QDockWidget):
         date_font.setPointSize(14)
         date_font.setBold(True)
         self.date_label.setFont(date_font)
-        self.date_label.setAlignment(Qt.AlignCenter)
+        self.date_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.date_label)
 
         # Step counter
         self.step_label = QLabel("")
-        self.step_label.setAlignment(Qt.AlignCenter)
+        self.step_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.step_label)
 
         # Slider
-        self.slider = QSlider(Qt.Horizontal)
+        self.slider = QSlider(Qt.Orientation.Horizontal)
         self.slider.setMinimum(0)
         self.slider.setMaximum(0)
         self.slider.setEnabled(False)
@@ -211,7 +213,7 @@ class TimeSliderDockWidget(QDockWidget):
         layout.addWidget(self.progress_bar)
 
         self.status_label = QLabel("")
-        self.status_label.setAlignment(Qt.AlignCenter)
+        self.status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.status_label.setVisible(False)
         layout.addWidget(self.status_label)
 

--- a/terrascope/dialogs/update_checker.py
+++ b/terrascope/dialogs/update_checker.py
@@ -10,8 +10,30 @@ import re
 import shutil
 import tempfile
 import zipfile
+from urllib.parse import urlsplit
 from urllib.request import urlopen, urlretrieve
 from urllib.error import URLError, HTTPError
+
+
+def _require_https(url):
+    """Raise ValueError unless ``url`` uses the https scheme.
+
+    The plugin only ever fetches from hardcoded GitHub URLs, but this guard
+    documents the invariant and keeps Bandit's B310 satisfied.
+
+    Args:
+        url: The URL to validate.
+
+    Returns:
+        The unchanged URL, for fluent use at call sites.
+
+    Raises:
+        ValueError: If the URL scheme is anything other than ``https``.
+    """
+    if urlsplit(url).scheme != "https":
+        raise ValueError(f"Refusing to open non-https URL: {url!r}")
+    return url
+
 
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
 from qgis.PyQt.QtWidgets import (
@@ -48,7 +70,9 @@ class VersionCheckWorker(QThread):
     def run(self):
         """Fetch the latest metadata from GitHub."""
         try:
-            with urlopen(METADATA_URL, timeout=15) as response:
+            with urlopen(
+                _require_https(METADATA_URL), timeout=15
+            ) as response:  # nosec B310 - https-only via _require_https
                 content = response.read().decode("utf-8")
 
             version_match = re.search(r"^version=(.+)$", content, re.MULTILINE)
@@ -114,7 +138,9 @@ class DownloadWorker(QThread):
                     percent = min(int((downloaded / total_size) * 50), 50)
                     self.progress.emit(10 + percent, "Downloading...")
 
-            urlretrieve(ZIP_URL, zip_path, reporthook)
+            urlretrieve(
+                _require_https(ZIP_URL), zip_path, reporthook
+            )  # nosec B310 - https-only via _require_https
 
             self.progress.emit(60, "Extracting files...")
 
@@ -241,7 +267,7 @@ class UpdateCheckerDialog(QDialog):
         header_font.setPointSize(14)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header_label)
 
         # Version info group
@@ -286,7 +312,7 @@ class UpdateCheckerDialog(QDialog):
         # Progress label
         self.progress_label = QLabel("")
         self.progress_label.setVisible(False)
-        self.progress_label.setAlignment(Qt.AlignCenter)
+        self.progress_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.progress_label)
 
         # Buttons
@@ -315,7 +341,7 @@ class UpdateCheckerDialog(QDialog):
         )
         info_label.setWordWrap(True)
         info_label.setOpenExternalLinks(True)
-        info_label.setAlignment(Qt.AlignCenter)
+        info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(info_label)
 
     def check_for_updates(self):
@@ -418,11 +444,11 @@ class UpdateCheckerDialog(QDialog):
             "IMPORTANT: You will need to restart QGIS after the update "
             "completes.\n\n"
             "Do you want to continue?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         self.check_btn.setEnabled(False)
@@ -520,10 +546,10 @@ class UpdateCheckerDialog(QDialog):
                 self,
                 "Download in Progress",
                 "A download is in progress. Are you sure you want to cancel?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
-            if reply != QMessageBox.Yes:
+            if reply != QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
             self.download_worker.terminate()

--- a/terrascope/dialogs/update_checker.py
+++ b/terrascope/dialogs/update_checker.py
@@ -14,27 +14,6 @@ from urllib.parse import urlsplit
 from urllib.request import urlopen, urlretrieve
 from urllib.error import URLError, HTTPError
 
-
-def _require_https(url):
-    """Raise ValueError unless ``url`` uses the https scheme.
-
-    The plugin only ever fetches from hardcoded GitHub URLs, but this guard
-    documents the invariant and keeps Bandit's B310 satisfied.
-
-    Args:
-        url: The URL to validate.
-
-    Returns:
-        The unchanged URL, for fluent use at call sites.
-
-    Raises:
-        ValueError: If the URL scheme is anything other than ``https``.
-    """
-    if urlsplit(url).scheme != "https":
-        raise ValueError(f"Refusing to open non-https URL: {url!r}")
-    return url
-
-
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
 from qgis.PyQt.QtWidgets import (
     QDialog,
@@ -59,6 +38,26 @@ METADATA_URL = (
     f"/{GITHUB_BRANCH}/{PLUGIN_PATH}/metadata.txt"
 )
 ZIP_URL = f"https://github.com/{GITHUB_REPO}/archive/refs/heads/{GITHUB_BRANCH}.zip"
+
+
+def _require_https(url):
+    """Raise ValueError unless ``url`` uses the https scheme.
+
+    The plugin only ever fetches from hardcoded GitHub URLs, but this guard
+    documents the invariant and keeps Bandit's B310 satisfied.
+
+    Args:
+        url: The URL to validate.
+
+    Returns:
+        The unchanged URL, for fluent use at call sites.
+
+    Raises:
+        ValueError: If the URL scheme is anything other than ``https``.
+    """
+    if urlsplit(url).scheme != "https":
+        raise ValueError(f"Refusing to open non-https URL: {url!r}")
+    return url
 
 
 class VersionCheckWorker(QThread):

--- a/terrascope/metadata.txt
+++ b/terrascope/metadata.txt
@@ -1,8 +1,9 @@
 [general]
 name=Terrascope
 qgisMinimumVersion=3.28
+qgisMaximumVersion=4.99
 description=Search and visualize Terrascope STAC API data with time slider and time series plotting.
-version=0.8.0
+version=0.9.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -31,6 +32,8 @@ experimental=false
 deprecated=False
 
 changelog=
+    0.9.0
+        - Compatible with QGIS 4.0 (Qt6) while keeping QGIS 3.28+ support
     0.8.0
         - Use uv for faster dependency installation (#20)
     0.7.0

--- a/terrascope/terrascope_plugin.py
+++ b/terrascope/terrascope_plugin.py
@@ -224,7 +224,7 @@ class TerrascopePlugin:
             try:
                 self._auth.logout()
             except Exception:
-                pass
+                pass  # nosec B110 - logout failures during plugin unload are not actionable
             self._auth = None
 
         # Remove actions from menu
@@ -259,7 +259,9 @@ class TerrascopePlugin:
                 self._search_dock.visibilityChanged.connect(
                     self._on_search_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._search_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._search_dock
+                )
                 self._search_dock.show()
                 self._search_dock.raise_()
                 return
@@ -303,7 +305,7 @@ class TerrascopePlugin:
                     self._on_time_slider_visibility_changed
                 )
                 self.iface.addDockWidget(
-                    Qt.BottomDockWidgetArea, self._time_slider_dock
+                    Qt.DockWidgetArea.BottomDockWidgetArea, self._time_slider_dock
                 )
                 self._time_slider_dock.show()
                 self._time_slider_dock.raise_()
@@ -347,7 +349,9 @@ class TerrascopePlugin:
                 self._time_series_dock.visibilityChanged.connect(
                     self._on_time_series_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._time_series_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._time_series_dock
+                )
                 self._time_series_dock.show()
                 self._time_series_dock.raise_()
                 return
@@ -387,7 +391,9 @@ class TerrascopePlugin:
                 self._settings_dock.visibilityChanged.connect(
                     self._on_settings_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._settings_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
+                )
                 self._settings_dock.show()
                 self._settings_dock.raise_()
                 return
@@ -425,7 +431,7 @@ class TerrascopePlugin:
                 if version_match:
                     version = version_match.group(1).strip()
         except Exception:
-            pass
+            pass  # nosec B110 - About box falls back to default version string
 
         about_text = f"""
 <h2>Terrascope Plugin for QGIS</h2>
@@ -472,7 +478,7 @@ class TerrascopePlugin:
 
         try:
             dialog = UpdateCheckerDialog(self.plugin_dir, self.iface.mainWindow())
-            dialog.exec_()
+            dialog.exec()
         except Exception as e:
             QMessageBox.critical(
                 self.iface.mainWindow(),
@@ -510,7 +516,7 @@ class TerrascopePlugin:
             from .dialogs.dependency_dialog import DependencyDialog
 
             dialog = DependencyDialog(self.iface.mainWindow())
-            dialog.exec_()
+            dialog.exec()
 
             # Re-check after dialog closes
             is_ready, _msg, _mr, _mo = get_venv_status()
@@ -534,7 +540,7 @@ class TerrascopePlugin:
             return
 
         dialog = DependencyDialog(self.iface.mainWindow())
-        dialog.exec_()
+        dialog.exec()
 
     def _try_auto_login(self):
         """Attempt auto-login if enabled in settings."""

--- a/terrascope/uv_manager.py
+++ b/terrascope/uv_manager.py
@@ -11,7 +11,7 @@ import os
 import sys
 import platform
 import stat
-import subprocess
+import subprocess  # nosec B404 - only used for hardcoded uv binary invocations, never user input
 import tarfile
 import zipfile
 import tempfile
@@ -33,12 +33,13 @@ UV_DIR = os.path.join(CACHE_DIR, "uv")
 UV_VERSION = "0.10.6"
 
 
-def _log(message, level=Qgis.Info):
+def _log(message, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning,
+            Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), "Terrascope", level=level)
 
@@ -198,7 +199,7 @@ def download_uv(
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
-            _log(error_msg, Qgis.Critical)
+            _log(error_msg, Qgis.MessageLevel.Critical)
             return False, error_msg
 
         if cancel_check and cancel_check():
@@ -260,7 +261,7 @@ def download_uv(
         success, verify_msg = verify_uv()
 
         if success:
-            _log("uv installed successfully", Qgis.Info)
+            _log("uv installed successfully", Qgis.MessageLevel.Info)
             return True, f"uv {UV_VERSION} installed successfully"
         else:
             # Verification failed; clean up partially installed uv so
@@ -274,7 +275,7 @@ def download_uv(
     except Exception as e:
         shutil.rmtree(UV_DIR, ignore_errors=True)
         error_msg = f"uv installation failed: {str(e)}"
-        _log(error_msg, Qgis.Critical)
+        _log(error_msg, Qgis.MessageLevel.Critical)
         return False, error_msg
     finally:
         if os.path.exists(temp_path):
@@ -304,7 +305,7 @@ def verify_uv() -> Tuple[bool, str]:
         if platform.system() == "Windows":
             kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 - hardcoded args, shell=False, uv binary path verified by os.path.exists above
             [uv_path, "--version"],
             capture_output=True,
             text=True,
@@ -315,11 +316,11 @@ def verify_uv() -> Tuple[bool, str]:
 
         if result.returncode == 0:
             version_output = result.stdout.strip()
-            _log(f"Verified uv: {version_output}", Qgis.Info)
+            _log(f"Verified uv: {version_output}", Qgis.MessageLevel.Info)
             return True, version_output
         else:
             error = result.stderr or "Unknown error"
-            _log(f"uv verification failed: {error}", Qgis.Warning)
+            _log(f"uv verification failed: {error}", Qgis.MessageLevel.Warning)
             return False, f"Verification failed: {error[:100]}"
 
     except subprocess.TimeoutExpired:
@@ -339,9 +340,9 @@ def remove_uv() -> Tuple[bool, str]:
 
     try:
         shutil.rmtree(UV_DIR)
-        _log("Removed uv installation", Qgis.Info)
+        _log("Removed uv installation", Qgis.MessageLevel.Info)
         return True, "uv removed"
     except Exception as e:
         error_msg = f"Failed to remove uv: {str(e)}"
-        _log(error_msg, Qgis.Warning)
+        _log(error_msg, Qgis.MessageLevel.Warning)
         return False, error_msg

--- a/terrascope/venv_manager.py
+++ b/terrascope/venv_manager.py
@@ -13,7 +13,7 @@ import importlib.util
 import os
 import platform
 import shutil
-import subprocess
+import subprocess  # nosec B404 - only used for hardcoded venv/uv invocations, never user input
 import sys
 
 _raw_cache_dir = os.environ.get("TERRASCOPE_CACHE_DIR")
@@ -196,7 +196,7 @@ def create_venv(progress_callback=None):
         else:
             cmd = [python_exe, "-m", "venv", VENV_DIR]
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 - hardcoded `uv venv` or `python -m venv`, shell=False
             cmd,
             capture_output=True,
             text=True,
@@ -216,7 +216,7 @@ def create_venv(progress_callback=None):
                 remove_uv()
                 use_uv = False
                 cmd = [python_exe, "-m", "venv", VENV_DIR]
-                result = subprocess.run(
+                result = subprocess.run(  # nosec B603 - hardcoded `python -m venv`, shell=False
                     cmd,
                     capture_output=True,
                     text=True,
@@ -246,7 +246,7 @@ def create_venv(progress_callback=None):
             progress_callback("Upgrading pip...")
 
         try:
-            subprocess.run(
+            subprocess.run(  # nosec B603 - hardcoded `pip install --upgrade pip` against the venv's own python
                 [
                     get_venv_python(),
                     "-m",
@@ -263,7 +263,7 @@ def create_venv(progress_callback=None):
                 **_subprocess_kwargs(),
             )
         except Exception:
-            pass  # pip upgrade failure is non-fatal
+            pass  # nosec B110 - pip upgrade failure is non-fatal; venv works without latest pip
 
     return True, "Virtual environment created successfully"
 
@@ -363,7 +363,7 @@ def _install_single_package(python, package, env):
         cmd.append(package)
 
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603 - hardcoded `pip install <pkg>` via venv python, shell=False
                 cmd,
                 capture_output=True,
                 text=True,
@@ -386,7 +386,7 @@ def _install_single_package(python, package, env):
                         "--no-cache-dir",
                         package,
                     ]
-                    ssl_result = subprocess.run(
+                    ssl_result = subprocess.run(  # nosec B603 - same pip command with --trusted-host retry, hardcoded args
                         cmd,
                         capture_output=True,
                         text=True,
@@ -429,7 +429,7 @@ def _install_single_package_uv(uv_path, python, package, env):
         cmd = list(base_cmd) + [package]
 
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603 - hardcoded `uv pip install <pkg>`, shell=False
                 cmd,
                 capture_output=True,
                 text=True,
@@ -451,7 +451,7 @@ def _install_single_package_uv(uv_path, python, package, env):
                         "files.pythonhosted.org",
                         package,
                     ]
-                    ssl_result = subprocess.run(
+                    ssl_result = subprocess.run(  # nosec B603 - same uv pip command with --allow-insecure-host retry, hardcoded args
                         ssl_cmd,
                         capture_output=True,
                         text=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,81 @@
+"""Shared pytest fixtures.
+
+Stubs the ``qgis`` package so the plugin's modules can be imported without a
+running QGIS instance. The stub reproduces the real ``qgis.PyQt`` shim
+behavior on Qt6: it re-exports ``QAction``, ``QActionGroup`` and ``QShortcut``
+from ``PyQt6.QtGui`` under ``qgis.PyQt.QtWidgets`` (they moved out of
+``QtWidgets`` in Qt6).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import PyQt6.QtCore
+import PyQt6.QtGui
+import PyQt6.QtNetwork
+import PyQt6.QtWidgets
+
+
+def _install_qgis_stub() -> None:
+    qgis = types.ModuleType("qgis")
+    qgis.__path__ = []
+    sys.modules["qgis"] = qgis
+
+    qgis_pyqt = types.ModuleType("qgis.PyQt")
+    qgis_pyqt.__path__ = []
+    sys.modules["qgis.PyQt"] = qgis_pyqt
+    qgis.PyQt = qgis_pyqt
+
+    pyqt_submodules = {
+        "QtCore": PyQt6.QtCore,
+        "QtGui": PyQt6.QtGui,
+        "QtNetwork": PyQt6.QtNetwork,
+        "QtWidgets": PyQt6.QtWidgets,
+    }
+    for name, real in pyqt_submodules.items():
+        alias = types.ModuleType(f"qgis.PyQt.{name}")
+        for attr in dir(real):
+            if not attr.startswith("_"):
+                setattr(alias, attr, getattr(real, attr))
+        sys.modules[f"qgis.PyQt.{name}"] = alias
+        setattr(qgis_pyqt, name, alias)
+
+    # Qt6: QAction, QActionGroup, and QShortcut live in QtGui. The real
+    # qgis.PyQt.QtWidgets shim re-exports them, so mirror that here.
+    qtwidgets_alias = sys.modules["qgis.PyQt.QtWidgets"]
+    for attr in ("QAction", "QActionGroup", "QShortcut"):
+        setattr(qtwidgets_alias, attr, getattr(PyQt6.QtGui, attr))
+
+    for submodule in ("QtSvg", "QtWebEngineWidgets", "sip"):
+        alias = MagicMock()
+        sys.modules[f"qgis.PyQt.{submodule}"] = alias
+        setattr(qgis_pyqt, submodule, alias)
+
+    for name in ("core", "gui", "utils"):
+        stub = MagicMock()
+        stub.__spec__ = None
+        sys.modules[f"qgis.{name}"] = stub
+        setattr(qgis, name, stub)
+
+
+def _install_third_party_stubs() -> None:
+    """Stub third-party packages that are only available inside QGIS.
+
+    ``osgeo`` (GDAL bindings) and ``matplotlib`` ship with QGIS but are not
+    installable into a plain CI venv. The smoke test only needs them to import,
+    not to function.
+    """
+    osgeo = types.ModuleType("osgeo")
+    osgeo.__path__ = []
+    osgeo.gdal = MagicMock()
+    osgeo.ogr = MagicMock()
+    osgeo.osr = MagicMock()
+    sys.modules["osgeo"] = osgeo
+    sys.modules["osgeo.gdal"] = osgeo.gdal
+    sys.modules["osgeo.ogr"] = osgeo.ogr
+    sys.modules["osgeo.osr"] = osgeo.osr
+
+
+_install_qgis_stub()
+_install_third_party_stubs()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,9 +62,8 @@ def _install_qgis_stub() -> None:
 def _install_third_party_stubs() -> None:
     """Stub third-party packages that are only available inside QGIS.
 
-    ``osgeo`` (GDAL bindings) and ``matplotlib`` ship with QGIS but are not
-    installable into a plain CI venv. The smoke test only needs them to import,
-    not to function.
+    ``osgeo`` (GDAL bindings) ships with QGIS but is not installable into a
+    plain CI venv. The smoke test only needs it to import, not to function.
     """
     osgeo = types.ModuleType("osgeo")
     osgeo.__path__ = []

--- a/tests/test_pyqt6_imports.py
+++ b/tests/test_pyqt6_imports.py
@@ -1,0 +1,54 @@
+"""Import-smoke tests that verify every plugin module loads under PyQt6.
+
+This catches short-form Qt enum regressions (for example ``Qt.AlignCenter``
+instead of ``Qt.AlignmentFlag.AlignCenter``) which raise ``AttributeError`` in
+PyQt6 during class-body evaluation.
+
+The plugin package is auto-discovered: the first sibling directory of
+``tests/`` that contains a ``metadata.txt`` is treated as the plugin root,
+so this file does not need to be edited per-plugin.
+"""
+
+import importlib
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _find_plugin_root() -> pathlib.Path:
+    """Return the plugin package directory (the one with metadata.txt)."""
+    candidates = [
+        p.parent for p in REPO_ROOT.glob("*/metadata.txt") if p.parent.name != "tests"
+    ]
+    if not candidates:
+        raise RuntimeError(
+            "Could not locate a QGIS plugin package (no */metadata.txt found "
+            f"under {REPO_ROOT})."
+        )
+    if len(candidates) > 1:
+        raise RuntimeError(
+            f"Multiple plugin packages found under {REPO_ROOT}: {candidates}. "
+            "Set PLUGIN_ROOT explicitly in this file."
+        )
+    return candidates[0]
+
+
+PLUGIN_ROOT = _find_plugin_root()
+
+
+def _module_names():
+    """Yield dotted module names for every .py file under the plugin package."""
+    for path in sorted(PLUGIN_ROOT.rglob("*.py")):
+        rel = path.relative_to(PLUGIN_ROOT.parent).with_suffix("")
+        parts = rel.parts
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        yield ".".join(parts)
+
+
+@pytest.mark.parametrize("module_name", list(_module_names()))
+def test_module_imports_under_pyqt6(module_name):
+    """Each plugin module must import cleanly when qgis.PyQt maps to PyQt6."""
+    importlib.import_module(module_name)


### PR DESCRIPTION
## Summary

Makes the plugin work on both QGIS 3.28+ (Qt5/PyQt5) and QGIS 4.0 (Qt6/PyQt6) from a single codebase, and gets it onto the official [QGIS 4 Ready plugin list](https://plugins.qgis.org/plugins/new_qgis_ready/).

- Fully-qualified short-form Qt enums (e.g. `Qt.AlignCenter` -> `Qt.AlignmentFlag.AlignCenter`, `Qt.LeftDockWidgetArea` -> `Qt.DockWidgetArea.LeftDockWidgetArea`, `Qt.UserRole` -> `Qt.ItemDataRole.UserRole`). The fully-qualified form works on PyQt5 >= 5.15 and PyQt6.
- Replaced `.exec_()` with `.exec()`, expanded `QMessageBox.Yes/No/Ok` to `QMessageBox.StandardButton.*`, qualified `Qgis.Info/Warning/Critical` to `Qgis.MessageLevel.*`.
- Bumped `version=0.9.0`, added `qgisMaximumVersion=4.99` (kept `qgisMinimumVersion=3.28`). No `supportsQt6=True` since that flag was removed from QGIS 4.
- Added `tests/test_pyqt6_imports.py` parametrized smoke test that imports every plugin module under PyQt6 (auto-discovers the package via `metadata.txt`).
- Hardened `urlopen`/`urlretrieve` in `update_checker.py` with a `_require_https()` guard so Bandit's B310 is satisfied with a real check, not just a suppression.
- Resolved every other Bandit finding (B105 false positive on env-var name, B110 try/except/pass on signal-disconnect best-effort cleanups, B404/B603 hardcoded subprocess invocations) with `# nosec <code> - <rationale>` comments.
- New `.github/workflows/ci.yml` runs the Bandit scan (matching the one `plugins.qgis.org` runs on upload) and the PyQt6 smoke test on Python 3.10 - 3.13.
- Added Bandit to `.pre-commit-config.yaml` so contributors catch issues before CI.

References:
- https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6
- https://plugins.qgis.org/docs/migrate-qgis4

## Test plan

Automated (already run locally and wired into CI):

- [x] `pre-commit run --all-files` (black, codespell, bandit) clean
- [x] `bandit -r terrascope` -> `No issues identified.`
- [x] `pytest tests/ -v` -> 13/13 modules import under PyQt6
- [x] `python -m compileall terrascope` clean under PyQt5/QGIS 3 env
- [x] No remaining short-form `Qt.*`, `QMessageBox.Yes/No/Ok`, `Qgis.Critical/Warning/Info`, or `.exec_()` calls

Manual smoke (please run before merging):

- [ ] Install branch into QGIS 3.28+ (Qt5): toolbar icon loads, Search dock opens, Settings dock opens (OAuth login still works), Time Slider dock opens and steps through frames, Time Series dock plots after a map click, About dialog renders, Check-for-Updates fetches metadata, Install-Dependencies dialog runs through the venv setup, all `QMessageBox` confirmations show Yes/No correctly.
- [ ] Repeat the same checks under a QGIS 4.0 nightly (Qt6).