### PR TITLE
fix: silence detect-secrets false positive on ENV_PASSWORD constant

### DIFF
--- a/terrascope/auth.py
+++ b/terrascope/auth.py
@@ -17,7 +17,7 @@ _logger = logging.getLogger(__name__)
 
 # Environment variable names
 ENV_USERNAME = "TERRASCOPE_USERNAME"
-ENV_PASSWORD = "TERRASCOPE_PASSWORD"  # nosec B105 - env var name, not a credential
+ENV_PASSWORD = "TERRASCOPE_PASSWORD"  # nosec B105 # pragma: allowlist secret - env var name, not a credential
 
 
 class TerrascopeAuth:


### PR DESCRIPTION
## Summary

The QGIS plugin repository upload scan ([screenshot of failure here](https://plugins.qgis.org)) runs both Bandit *and* `detect-secrets`. Bandit passed (0 issues), but `detect-secrets` flagged `terrascope/auth.py:20` as a "Potential Secret Keyword" because the variable name contains `PASSWORD`.

The value `"TERRASCOPE_PASSWORD"` is the *name* of an environment variable, not an actual credential. We already had `# nosec B105` to silence Bandit, but `detect-secrets` uses its own pragma. Adds `# pragma: allowlist secret` on the same line so the upload scan passes.

## Test plan

- [x] `detect-secrets scan terrascope/auth.py` returns no hits.
- [x] `bandit -r terrascope` still reports `No issues identified.`
- [x] `flake8 terrascope/ --max-line-length=120 --ignore=E501,W503` clean.
- [x] `pre-commit run --files terrascope/auth.py` clean.
- [x] `pytest tests/` still 13/13.