### PR TITLE
Fix macOS QGIS dependency installer

### DIFF
--- a/terrascope/metadata.txt
+++ b/terrascope/metadata.txt
@@ -31,7 +31,7 @@ icon=icons/icon.png
 experimental=false
 deprecated=False
 
-changelog=
+changelog=Fix macOS QGIS installer dependency installation and bump patch version.
     0.9.1
         - Fixed dependency installer Python detection for macOS QGIS app bundles
     0.9.0

--- a/terrascope/metadata.txt
+++ b/terrascope/metadata.txt
@@ -3,7 +3,7 @@ name=Terrascope
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Search and visualize Terrascope STAC API data with time slider and time series plotting.
-version=0.9.1
+version=0.9.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 

--- a/terrascope/metadata.txt
+++ b/terrascope/metadata.txt
@@ -31,7 +31,9 @@ icon=icons/icon.png
 experimental=false
 deprecated=False
 
-changelog=Fix macOS QGIS installer dependency installation and bump patch version.
+changelog=
+    0.9.2
+        - Fix macOS QGIS installer dependency installation
     0.9.1
         - Fixed dependency installer Python detection for macOS QGIS app bundles
     0.9.0

--- a/terrascope/venv_manager.py
+++ b/terrascope/venv_manager.py
@@ -197,7 +197,9 @@ def create_venv(progress_callback=None):
     try:
         if use_uv:
             uv_path = get_uv_path()
-            uv_python = python_exe or f"{sys.version_info.major}.{sys.version_info.minor}"
+            uv_python = (
+                python_exe or f"{sys.version_info.major}.{sys.version_info.minor}"
+            )
             cmd = [uv_path, "venv"]
             if python_exe is None:
                 cmd.append("--managed-python")

--- a/terrascope/venv_manager.py
+++ b/terrascope/venv_manager.py
@@ -185,18 +185,26 @@ def create_venv(progress_callback=None):
 
     os.makedirs(CACHE_DIR, exist_ok=True)
 
+    python_exe = None
+    python_lookup_error = ""
     try:
         python_exe = _find_python_executable()
     except RuntimeError as exc:
-        return False, str(exc)
+        python_lookup_error = str(exc)
     env = _get_clean_env()
     use_uv = uv_exists()
 
     try:
         if use_uv:
             uv_path = get_uv_path()
-            cmd = [uv_path, "venv", "--python", python_exe, VENV_DIR]
+            uv_python = python_exe or f"{sys.version_info.major}.{sys.version_info.minor}"
+            cmd = [uv_path, "venv"]
+            if python_exe is None:
+                cmd.append("--managed-python")
+            cmd += ["--python", uv_python, VENV_DIR]
         else:
+            if python_exe is None:
+                return False, python_lookup_error
             cmd = [python_exe, "-m", "venv", VENV_DIR]
 
         result = subprocess.run(  # nosec B603 - hardcoded `uv venv` or `python -m venv`, shell=False
@@ -208,7 +216,7 @@ def create_venv(progress_callback=None):
             **_subprocess_kwargs(),
         )
         if result.returncode != 0:
-            if use_uv:
+            if use_uv and python_exe:
                 # uv venv failed; fall back to stdlib venv
                 if progress_callback:
                     progress_callback(
@@ -595,9 +603,25 @@ def _is_python_executable_name(path):
     )
 
 
+def _is_macos_qgis_app_bundle_python(path):
+    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    if not (platform.system() == "Darwin" or sys.platform == "darwin"):
+        return False
+    parts = os.path.abspath(path).split(os.sep)
+    for idx, part in enumerate(parts):
+        lower = part.lower()
+        if not (lower.startswith("qgis") and lower.endswith(".app")):
+            continue
+        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+    return False
+
+
 def _python_candidate_matches_runtime(path):
     """Return True when a candidate is executable and matches QGIS Python."""
     if not path or not os.path.isfile(path) or not _is_python_executable_name(path):
+        return False
+
+    if _is_macos_qgis_app_bundle_python(path):
         return False
     try:
         result = subprocess.run(  # nosec B603

--- a/terrascope/venv_manager.py
+++ b/terrascope/venv_manager.py
@@ -606,7 +606,7 @@ def _is_python_executable_name(path):
 
 
 def _is_macos_qgis_app_bundle_python(path):
-    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    """Return True for unsafe Python launchers in QGIS.app/Contents/MacOS."""
     if not (platform.system() == "Darwin" or sys.platform == "darwin"):
         return False
     parts = os.path.abspath(path).split(os.sep)
@@ -614,7 +614,12 @@ def _is_macos_qgis_app_bundle_python(path):
         lower = part.lower()
         if not (lower.startswith("qgis") and lower.endswith(".app")):
             continue
-        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+        if idx + 2 >= len(parts):
+            return False
+        if parts[idx + 1].lower() != "contents" or parts[idx + 2].lower() != "macos":
+            return False
+        name = os.path.basename(path).lower()
+        return name.startswith("qgis") or _is_python_executable_name(path)
     return False
 
 


### PR DESCRIPTION
## Summary
- Reject macOS QGIS app-bundle Python wrappers for dependency virtual environment creation where this plugin manages dependency venvs.
- Use uv-managed Python when no safe local Python interpreter is available.
- Bump the QGIS plugin patch version in `metadata.txt`.

## Root Cause
Official macOS QGIS installer builds can expose Python wrappers inside `QGIS*.app/Contents/MacOS` that either fail to start outside QGIS or create virtual environments pointing at the QGIS CI build prefix. Those venvs fail during dependency installation with missing stdlib modules such as `encodings`.

## Validation
- `python -m py_compile terrascope/venv_manager.py`
- Focused local QGIS plugin tests were run from the source checkout before publishing these PRs.
